### PR TITLE
More serializer love

### DIFF
--- a/revivalkit/serializers/highest_pickle.py
+++ b/revivalkit/serializers/highest_pickle.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
-try:
+try:                    # pragma: no cover
     # py2
     import cPickle as pickle
-except ImportError:
+except ImportError:     # pragma: no cover
     # py3
     import pickle
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,74 @@
+import pickle
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+
+extra_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+REVIVE_SUBPROCESS_PROGRAM = ("""
+import os
+import sys
+
+# Change cwd and script name to fool revivalkit for testing.
+os.chdir(sys.argv[1])
+sys.argv[0] = '___revive_subprocess'
+
+sys.path.append(sys.argv[2])
+from revivalkit import revive
+
+o = revive()
+if not getattr(o, 'queue', []):
+    o.queue = ['james', 'harvey', 'oswald', 'bruce', 'selina']
+while o.queue:
+    n = o.queue.pop()
+    if n == 'oswald':
+        raise SystemExit(1)
+    print(n)
+""")
+
+
+@pytest.fixture
+def tempdir(request):
+    dirname = tempfile.mkdtemp()
+
+    def finalizer():
+        shutil.rmtree(dirname)
+
+    request.addfinalizer(finalizer)
+    return dirname
+
+
+@pytest.fixture
+def revive_subprocess_args(tempdir):
+    args = [
+        sys.executable,
+        '-c',
+        REVIVE_SUBPROCESS_PROGRAM,
+        tempdir,
+        extra_path,
+    ]
+    return args
+
+
+def test_revive(revive_subprocess_args):
+    with pytest.raises(subprocess.CalledProcessError) as ctx:
+        subprocess.check_output(revive_subprocess_args)
+    assert ctx.value.returncode == 1
+    assert ctx.value.output == b'selina\nbruce\n'
+
+    my_coffin = os.path.join(
+        revive_subprocess_args[3],
+        '___revive_subprocess.coffin',
+    )
+    with open(my_coffin, 'rb') as f:
+        o = pickle.load(f)
+    assert o.queue == ['james', 'harvey']
+
+    output = subprocess.check_output(revive_subprocess_args)
+    assert output == b'harvey\njames\n'

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,44 +1,9 @@
-import collections
 import pickle
 import tempfile
 
 import pytest
 
 from revivalkit import serializers
-
-
-@pytest.fixture
-def text_file(request):
-    f = tempfile.NamedTemporaryFile(mode='w+')
-
-    def finalizer():
-        f.close()
-
-    request.addfinalizer(finalizer)
-    return f
-
-
-def test_json_dump(text_file):
-    serializers.json.dump(
-        collections.OrderedDict([('name', 'mosky'), ('numbers', [19, 42])]),
-        text_file.name,
-    )
-    text_file.flush()
-    assert text_file.read() == '{"name": "mosky", "numbers": [19, 42]}'
-
-
-@pytest.fixture
-def text_file_with_content(request):
-    f = text_file(request)
-    f.write('{"name": "mosky", "numbers": [19, 42]}')
-    f.flush()
-    return f
-
-
-def test_json_load(text_file_with_content):
-    assert serializers.json.load(text_file_with_content.name) == {
-        'name': 'mosky', 'numbers': [19, 42],
-    }
 
 
 class Thing(object):
@@ -67,27 +32,28 @@ def binary_file(request):
     return f
 
 
-def test_pickle_dump(capsys, binary_file, thing):
-    serializers.pickle.dump(thing, binary_file.name)
+def test_highest_pickle_dump(capsys, binary_file, thing):
+    serializers.highest_pickle.dump(thing, binary_file)
     binary_file.flush()
+    binary_file.seek(0)
+
     o = pickle.load(binary_file)
     assert o.a == 3
-
     o.say_hello()
     assert capsys.readouterr() == ('hello!\n', '')
 
 
 @pytest.fixture
-def binary_file_with_content(request):
+def file_with_pickle(request):
     f = binary_file(request)
     pickle.dump(thing(), f)
     f.flush()
+    f.seek(0)
     return f
 
 
-def test_pickle_load(capsys, binary_file_with_content):
-    o = serializers.pickle.load(binary_file_with_content.name)
+def test_highest_pickle_load(capsys, file_with_pickle):
+    o = serializers.highest_pickle.load(file_with_pickle)
     assert o.a == 3
-
     o.say_hello()
     assert capsys.readouterr() == ('hello!\n', '')


### PR DESCRIPTION
Fixed Pickle tests and remove JSON tests for #2. Also added a test for `revive` using a subprocess. A bit hackish but makes sense (I think).
