### PR TITLE
Fix sigint handler set/restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ clean:
 		-name '__pycache__' -o \
 		-name '*.coffin' \
 	\)  -print -delete
+
+lint:
+	flake8 revivalkit --ignore=F401,E203,E221,E226,E261,E302

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+flake8
 pytest
 pytest-cov
 tox

--- a/revivalkit/before_exit.py
+++ b/revivalkit/before_exit.py
@@ -15,6 +15,7 @@ def _print_still_working_message(signum, frame):
 _orig_sigint_handler = signal.getsignal(signal.SIGINT)
 
 def _mute_sigint():
+    global _orig_sigint_handler
     _orig_sigint_handler = signal.getsignal(signal.SIGINT)
     signal.signal(signal.SIGINT, _print_still_working_message)
     log.debug('muted sigint')

--- a/revivalkit/log.py
+++ b/revivalkit/log.py
@@ -5,5 +5,6 @@ import sys
 to_print_debug = False
 
 def debug(*args, **arg_ds):
-    if not to_print_debug: return
+    if not to_print_debug:
+        return
     print('revivalkit:debug:', *args, file=sys.stderr, **arg_ds)

--- a/tests/test_before_exit.py
+++ b/tests/test_before_exit.py
@@ -1,0 +1,59 @@
+import os
+import signal
+import sys
+
+import pytest
+
+from revivalkit import before_exit
+
+
+pid = os.getpid()
+
+
+@pytest.fixture
+def backup_sigint_handler(request):
+    handler = signal.getsignal(signal.SIGINT)
+
+    def finalizer():
+        signal.signal(signal.SIGINT, handler)
+
+    request.addfinalizer(finalizer)
+    return handler
+
+
+def test_mute_default_sigint(capsys, backup_sigint_handler):
+    before_exit._mute_sigint()
+    os.kill(pid, signal.SIGINT)
+    assert capsys.readouterr() == (
+        '', '{}: still cleaning up ...\n'.format(sys.argv[0]),
+    )
+
+
+def custom_sigint_handler(signum, frame):
+    pass
+
+
+@pytest.fixture
+def change_sigint_handler(backup_sigint_handler):
+    signal.signal(signal.SIGINT, custom_sigint_handler)
+    os.kill(pid, signal.SIGINT)     # Make sure the handler is changed.
+    return custom_sigint_handler
+
+
+def test_restore_sigint(capsys, change_sigint_handler):
+    before_exit._restore_sigint()
+    with pytest.raises(KeyboardInterrupt):
+        os.kill(pid, signal.SIGINT)
+
+
+def test_mute_restore_custom_sigint(change_sigint_handler):
+    assert signal.getsignal(signal.SIGINT) is custom_sigint_handler
+
+    before_exit._mute_sigint()
+    assert (
+        signal.getsignal(signal.SIGINT)
+        is before_exit._print_still_working_message
+    )
+
+    before_exit._restore_sigint()
+    assert signal.getsignal(signal.SIGINT) is custom_sigint_handler

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,7 @@ import pytest
 extra_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-REVIVE_SUBPROCESS_PROGRAM = ("""
+REVIVE_SUBPROCESS_PROGRAM = """
 import os
 import sys
 
@@ -30,7 +30,7 @@ while o.queue:
     if n == 'oswald':
         raise SystemExit(1)
     print(n)
-""")
+"""
 
 
 @pytest.fixture


### PR DESCRIPTION
Assignment of `_orig_sigint_handler` inside function requires a `global` statement! Tests added.

I caught this with `flake8` (an “unused variable” warning), so a `lint` command is added to the Makefile in its honour. :p
