### PR TITLE
Text flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test test-all clean
 
 test:
-	py.test --cov-config .coveragerc --cov=revivalkit
+	py.test --cov=revivalkit
 
 test-all:
 	tox
@@ -14,4 +14,4 @@ clean:
 	\)  -print -delete
 
 lint:
-	flake8 revivalkit --ignore=F401,E203,E221,E226,E261,E302
+	flake8 revivalkit

--- a/revivalkit/core.py
+++ b/revivalkit/core.py
@@ -44,26 +44,27 @@ def _to_coffin_path(name):
     # auto
     return join(_main_mod_dir_path, _add_ext(name))
 
+def _open_for_serializer(name, mode, in_text, serializer):
+    if in_text is None:
+        in_text = getattr(serializer, 'IN_TEXT', False)
+    if not in_text:
+        mode += 'b'
+    return open(_to_coffin_path(name), mode)
+
 def _encoffin(name, in_text, serializer, x):
     log.debug('encoffining', name, '...')
-    with open(
-        _to_coffin_path(name),
-        'w' if in_text else 'wb'
-    ) as f:
+    with _open_for_serializer(name, 'w', in_text, serializer) as f:
         return serializer.dump(x, f)
 
 def _decoffin(name, in_text, serializer):
     log.debug('decoffining', name, '...')
-    with open(
-        _to_coffin_path(name),
-        'r' if in_text else 'rb'
-    ) as f:
+    with _open_for_serializer(name, 'r', in_text, serializer) as f:
         return serializer.load(f)
 
 class _Object(object):
     pass
 
-def revive(make_default=None, name=None, serializer=None, in_text=False):
+def revive(make_default=None, name=None, serializer=None, in_text=None):
 
     if make_default is None:
         make_default = _Object

--- a/revivalkit/core.py
+++ b/revivalkit/core.py
@@ -29,7 +29,7 @@ _main_mod_dir_path = dirname(_main_mod_path)
 ext = '.coffin'
 
 def _add_ext(path):
-    return path+ext
+    return path + ext
 
 def _to_coffin_path(name):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+ignore = F401,E203,E221,E226,E261,E302
+
+[wheel]
+universal = 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,10 +8,9 @@ import tempfile
 import pytest
 
 
-extra_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXTRA_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
-REVIVE_SUBPROCESS_PROGRAM = """
+DEFAULT_PROGRAM = """
 import os
 import sys
 
@@ -44,31 +43,87 @@ def tempdir(request):
     return dirname
 
 
-@pytest.fixture
-def revive_subprocess_args(tempdir):
-    args = [
-        sys.executable,
-        '-c',
-        REVIVE_SUBPROCESS_PROGRAM,
-        tempdir,
-        extra_path,
+def test_revive_default(tempdir):
+    subprocess_args = [
+        sys.executable, '-c', DEFAULT_PROGRAM,
+        tempdir, EXTRA_PATH,
     ]
-    return args
-
-
-def test_revive(revive_subprocess_args):
     with pytest.raises(subprocess.CalledProcessError) as ctx:
-        subprocess.check_output(revive_subprocess_args)
+        subprocess.check_output(subprocess_args)
     assert ctx.value.returncode == 1
     assert ctx.value.output == b'selina\nbruce\n'
 
-    my_coffin = os.path.join(
-        revive_subprocess_args[3],
-        '___revive_subprocess.coffin',
-    )
-    with open(my_coffin, 'rb') as f:
+    with open(os.path.join(tempdir, '___revive_subprocess.coffin'), 'rb') as f:
         o = pickle.load(f)
     assert o.queue == ['james', 'harvey']
 
-    output = subprocess.check_output(revive_subprocess_args)
+    output = subprocess.check_output(subprocess_args)
+    assert output == b'harvey\njames\n'
+
+
+JSON_PROGRAM_TEMPLATE = """
+import json
+import os
+import sys
+
+# Change cwd and script name to fool revivalkit for testing.
+os.chdir(sys.argv[1])
+sys.argv[0] = '___revive_subprocess'
+
+sys.path.append(sys.argv[2])
+from revivalkit import revive
+
+{serializer_code}
+
+queue = revive({revive_code})
+if not queue:
+    queue.extend(['james', 'harvey', 'oswald', 'bruce', 'selina'])
+while queue:
+    n = queue.pop()
+    if n == 'oswald':
+        raise SystemExit(1)
+    print(n)
+"""
+
+JSON_SERIALIZER_CODE = """
+class JSONSerializer(object):
+    IN_TEXT = True
+    load = staticmethod(json.load)
+    dump = staticmethod(json.dump)
+"""
+
+@pytest.fixture(params=[
+    {'serializer_code': '',
+     'revive_code': 'make_default=list, serializer=json, in_text=True'},
+    {'serializer_code': JSON_SERIALIZER_CODE,
+     'revive_code': 'make_default=list, serializer=JSONSerializer'},
+])
+def json_serializer_params(request):
+    return request.param
+
+
+def test_revive_json(tempdir, json_serializer_params):
+    """Test two variants of the "in-text" hint feature.
+
+    The JSON_PROGRAM variant uses the built-in ``json`` module as the
+    serializer, and supply the ``in_text`` argument to ``revive`` manually.
+    The JSON_SERIALIZER_PROGRAM wraps ``json`` in a thin wrapper with
+    an ``IN_TEXT`` flag. This eliminates the ``in_text`` hint when
+    calling ``revive``.
+    """
+    subprocess_args = [
+        sys.executable, '-c',
+        JSON_PROGRAM_TEMPLATE.format(**json_serializer_params),
+        tempdir,
+        EXTRA_PATH,
+    ]
+    with pytest.raises(subprocess.CalledProcessError) as ctx:
+        subprocess.check_output(subprocess_args)
+    assert ctx.value.returncode == 1
+    assert ctx.value.output == b'selina\nbruce\n'
+
+    with open(os.path.join(tempdir, '___revive_subprocess.coffin')) as f:
+        assert f.read() == '["james", "harvey"]'
+
+    output = subprocess.check_output(subprocess_args)
     assert output == b'harvey\njames\n'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27, py33, py34, py35, pypy
 
 [testenv]
-commands = py.test --cov-config .coveragerc --cov=revivalkit
+commands = py.test --cov=revivalkit
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
Serialiser `IN_TEXT` flag implemented. This is used if `in_text` is not specified (or is `None`) in `revive()`. Tests added.

I also re-organised the tests a bit to use [test parameters](https://pytest.org/latest/parametrize.html), which make testing option variants easier.
